### PR TITLE
Add batch_deletion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The Cloud Spanner adapter has only the deletion strategy.
 
 ## Strategy configuration options
 
+* `:batch_deletion` - When set to `true`, [batch DML](https://cloud.google.com/spanner/docs/dml-tasks#use-batch) is used for cleaning. Defaults to `false`.
 * `:cache_tables` - When set to `true`, the list of tables to delete and the deletion orders will be
   read from the Cloud Spanner once, otherwise they will be read before each deletion. Defaults to
   `true`.

--- a/scripts/performance_test.rb
+++ b/scripts/performance_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+raise "emulator is enabled" if ENV["SPANNER_EMULATOR_HOST"]
+
+require "base64"
+require "benchmark"
+
+require_relative "../spec/spanner_admin"
+require_relative "../lib/database_cleaner/spanner/deletion"
+
+class BenchmarkRunner
+  def initialize(n = 1)
+    @n = n
+  end
+
+  def run
+    puts "Creating instance..."
+    admin.create_instance
+    puts "Creating database..."
+    admin.create_database
+    puts
+
+    Benchmark.bm(20) do |x|
+      run_test(x, :test_batch_update)
+      run_test(x, :test_delete_each)
+    end
+  ensure
+    puts
+    puts "Dropping database..."
+    admin.drop_database
+  end
+
+  private
+
+  def test_batch_update
+    cleaner = DatabaseCleaner::Spanner::Deletion.new(batch_deletion: true)
+    cleaner.db = db
+    cleaner.clean
+  end
+
+  def test_delete_each
+    cleaner = DatabaseCleaner::Spanner::Deletion.new(batch_deletion: false)
+    cleaner.db = db
+    cleaner.clean
+  end
+
+  def run_test(x, test_name)
+    preprocess
+    x.report(test_name) do
+      @n.times do
+        send(test_name)
+      end
+    end
+  ensure
+    postprocess
+  end
+
+  def preprocess
+    client.insert("Users", [{UserId: "user1"}, {UserId: "user2"}])
+    client.insert("Followings", [{FolloweeId: "user1", FollowerId: "user2"}])
+    client.insert("Posts", [{PostId: "post1", UserId: "user1", Text: "text"}])
+    client.insert("Bookmarks", [{UserId: "user2", PostId: "post1"}])
+    client.insert("Images", [{PostId: "post1", ImageId: "image1", Image: Base64.encode64("")}])
+    client.insert("Replies", [{PostId: "post1", ReplyId: "reply1", UserId: "user2", Text: "text"}])
+    client.insert("Likes", [{PostId: "post1", LikerId: "user2"}])
+    client.insert("ChatRooms", [{ChatRoomId: "chatRoom1", ChatRoomName: "name"}])
+    client.insert("ChatRoomMembers", [{ChatRoomId: "chatRoom1", UserId: "user1"}])
+    client.insert("ChatRoomMessages", [{ChatRoomId: "chatRoom1", ChatRoomMessageId: "chatRoomMessage1", UserId: "user1", Text: "text"}])
+    client.insert("Communities", [{CommunityId: "community1", CommunityName: "name", OwnerId: "user1"}])
+    client.insert("CommunityBelongings", [{UserId: "user1", CommunityId: "community1"}])
+    client.insert("CommunityPosts", [{CommunityId: "community1", PostId: "post1"}])
+  end
+
+  def postprocess
+    %w[
+      Users Followings Posts Bookmarks Images Replies Likes
+      ChatRooms ChatRoomMembers ChatRoomMessages
+      Communities CommunityBelongings CommunityPosts
+    ].each do |table|
+      count = count_rows(table)
+      if count != 0
+        raise "#{table} was not cleaned up"
+      end
+    end
+  end
+
+  def count_rows(table)
+    result = client.execute_query("SELECT COUNT(1) FROM #{table}")
+    result.rows.first[0]
+  end
+
+  def admin
+    @admin ||= SpannerAdmin.new(
+      project_id: project_id,
+      instance_id: instance_id,
+      database_id: database_id,
+      schema_file: File.expand_path("./schema.sql", __dir__)
+    )
+  end
+
+  def client
+    @client ||= Google::Cloud::Spanner.new(project_id: project_id)
+      .client(instance_id, database_id)
+  end
+
+  def project_id
+    @project_id ||= SpannerAdmin.get_project_id
+  end
+
+  def instance_id
+    @instance_id ||= ENV.fetch("SPANNER_INSTANCE_ID")
+  end
+
+  def database_id
+    @database_id ||= "performance-#{Time.now.to_i}"
+  end
+
+  def db
+    @db ||= {
+      project_id: project_id,
+      instance_id: instance_id,
+      database_id: database_id
+    }
+  end
+end
+
+BenchmarkRunner.new(100).run

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -1,0 +1,93 @@
+CREATE TABLE Users (
+  UserId STRING(36) NOT NULL,
+) PRIMARY KEY (UserId);
+
+CREATE TABLE Followings (
+  FolloweeId STRING(36) NOT NULL,
+  FollowerId STRING(36) NOT NULL,
+
+  FOREIGN KEY (FolloweeId) REFERENCES Users (UserId),
+  FOREIGN KEY (FollowerId) REFERENCES Users (UserId),
+) PRIMARY KEY (FolloweeId, FollowerId);
+
+CREATE TABLE Posts (
+  PostId STRING(36)  NOT NULL,
+  UserId STRING(36)  NOT NULL,
+  Text   STRING(MAX) NOT NULL,
+
+  FOREIGN KEY (UserId) REFERENCES Users (UserId),
+) PRIMARY KEY (PostId);
+
+CREATE TABLE Bookmarks (
+  UserId STRING(36) NOT NULL,
+  PostId STRING(36) NOT NULL,
+
+  FOREIGN KEY (PostId) REFERENCES Posts (PostId),
+) PRIMARY KEY (UserId, PostId), INTERLEAVE IN PARENT Users;
+
+CREATE TABLE Images (
+  PostId  STRING(36)  NOT NULL,
+  ImageId STRING(36)  NOT NULL,
+  Image   BYTES(1024) NOT NULL,
+) PRIMARY KEY (PostId, ImageId), INTERLEAVE IN PARENT Posts;
+
+CREATE TABLE Replies (
+  PostId  STRING(36)  NOT NULL,
+  ReplyId STRING(36)  NOT NULL,
+  UserId  STRING(36)  NOT NULL,
+  Text    STRING(MAX) NOT NULL,
+
+  FOREIGN KEY (UserId) REFERENCES Users (UserId),
+) PRIMARY KEY (PostId, ReplyId), INTERLEAVE IN PARENT Posts;
+
+CREATE TABLE Likes (
+  PostId  STRING(36) NOT NULL,
+  LikerId STRING(36) NOT NULL,
+
+  FOREIGN KEY (LikerId) REFERENCES Users (UserId),
+) PRIMARY KEY (PostId, LikerId), INTERLEAVE IN PARENT Posts;
+
+CREATE TABLE ChatRooms (
+  ChatRoomId   STRING(36)  NOT NULL,
+  ChatRoomName STRING(128) NOT NULL,
+) PRIMARY KEY (ChatRoomId);
+
+CREATE TABLE ChatRoomMembers (
+  ChatRoomId STRING(36) NOT NULL,
+  UserId     STRING(36) NOT NULL,
+
+  FOREIGN KEY (ChatRoomId) REFERENCES ChatRooms (ChatRoomId),
+  FOREIGN KEY (UserId) REFERENCES Users (UserId),
+) PRIMARY KEY (ChatRoomId, UserId);
+
+CREATE TABLE ChatRoomMessages (
+  ChatRoomId        STRING(36)  NOT NULL,
+  ChatRoomMessageId STRING(36)  NOT NULL,
+  UserId            STRING(36)  NOT NULL,
+  Text              STRING(MAX) NOT NULL,
+
+  FOREIGN KEY (ChatRoomId, UserId) REFERENCES ChatRoomMembers (ChatRoomId, UserId),
+) PRIMARY KEY (ChatRoomId, ChatRoomMessageId), INTERLEAVE IN PARENT ChatRooms;
+
+CREATE TABLE Communities (
+  CommunityId   STRING(36)  NOT NULL,
+  CommunityName STRING(128) NOT NULL,
+  OwnerId       STRING(36)  NOT NULL,
+
+  FOREIGN KEY (OwnerId) REFERENCES Users (UserId),
+) PRIMARY KEY (CommunityId);
+
+CREATE TABLE CommunityBelongings (
+  UserId      STRING(36) NOT NULL,
+  CommunityId STRING(36) NOT NULL,
+
+  FOREIGN KEY (CommunityId) REFERENCES Communities (CommunityId),
+) PRIMARY KEY (UserId, CommunityId), INTERLEAVE IN PARENT Users;
+
+CREATE TABLE CommunityPosts (
+  CommunityId STRING(36) NOT NULL,
+  PostId      STRING(36) NOT NULL,
+
+  FOREIGN KEY (PostId) REFERENCES Posts (PostId),
+) PRIMARY KEY (CommunityId, PostId), INTERLEAVE IN PARENT Communities;
+

--- a/spec/database_cleaner/spanner/deletion_spec.rb
+++ b/spec/database_cleaner/spanner/deletion_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe DatabaseCleaner::Spanner::Deletion do
   include Helper
 
   subject {
-    described_class.new(only: only, except: except).tap do |instance|
+    described_class.new(
+      only: only,
+      except: except,
+      batch_deletion: batch_deletion
+    ).tap do |instance|
       instance.db = {
         project_id: RSpec.configuration.project_id,
         instance_id: RSpec.configuration.instance_id,
@@ -63,8 +67,26 @@ RSpec.describe DatabaseCleaner::Spanner::Deletion do
 
   let(:only) { [] }
   let(:except) { [] }
+  let(:batch_deletion) { false }
 
   context "by default" do
+    it "deletes all tables" do
+      subject.clean
+
+      expect(count_rows("Products")).to be_zero
+      expect(count_rows("Customers")).to be_zero
+      expect(count_rows("Orders")).to be_zero
+      expect(count_rows("Singers")).to be_zero
+      expect(count_rows("Albums")).to be_zero
+      expect(count_rows("Songs")).to be_zero
+      expect(count_rows("OnlyTable")).to be_zero
+      expect(count_rows("ExceptTable")).to be_zero
+    end
+  end
+
+  context "with batch deletion" do
+    let(:batch_deletion) { true }
+
     it "deletes all tables" do
       subject.clean
 

--- a/spec/spanner_admin.rb
+++ b/spec/spanner_admin.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "google/cloud/spanner"
+require "google/cloud/spanner/admin/database"
+require "google/cloud/spanner/admin/instance"
+
+class SpannerAdmin
+  def self.get_project_id
+    return ENV["PROJECT_ID"] if ENV["PROJECT_ID"]
+
+    Google::Cloud::Spanner.default_credentials.project_id
+  end
+
+  def initialize(project_id:, instance_id:, database_id:, schema_file:)
+    @project_id = project_id
+    @instance_id = instance_id
+    @database_id = database_id
+    @schema_file = schema_file
+  end
+
+  def create_instance
+    return if instance_exists?
+
+    instance_admin.create_instance(
+      parent: project_path,
+      instance_id: @instance_id,
+      instance: {
+        name: instance_path,
+        config: instance_config_path,
+        display_name: @instance_id,
+        node_count: 1
+      }
+    ).wait_until_done!
+  end
+
+  def create_database
+    database_admin.create_database(
+      parent: instance_path,
+      create_statement: "CREATE DATABASE `#{@database_id}`",
+      extra_statements: ddls
+    ).wait_until_done!
+  end
+
+  def drop_database
+    database_admin.drop_database(database: database_path)
+  end
+
+  private
+
+  def ddls
+    File.read(@schema_file).split(";").map(&:strip).reject(&:empty?)
+  end
+
+  def instance_exists?
+    instance_admin.list_instances(parent: project_path)
+      .any? { |instance| instance.name == instance_path }
+  end
+
+  def project_path
+    @project_path ||= instance_admin.project_path(project: @project_id)
+  end
+
+  def instance_config_path
+    @instance_config_path ||= instance_admin.instance_config_path(
+      project: @project_id,
+      instance_config: "regional-us-central1"
+    )
+  end
+
+  def instance_path
+    @instance_path ||= instance_admin.instance_path(
+      project: @project_id,
+      instance: @instance_id
+    )
+  end
+
+  def database_path
+    @database_path ||= database_admin.database_path(
+      project: @project_id,
+      instance: @instance_id,
+      database: @database_id
+    )
+  end
+
+  def instance_admin
+    @instance_admin ||= Google::Cloud::Spanner::Admin::Instance.instance_admin(
+      project_id: @project_id
+    )
+  end
+
+  def database_admin
+    @database_admin ||= Google::Cloud::Spanner::Admin::Database.database_admin(
+      project_id: @project_id
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,99 +15,8 @@ end
 require "database_cleaner/spanner"
 
 require "google/cloud/spanner"
-require "google/cloud/spanner/admin/database"
-require "google/cloud/spanner/admin/instance"
 
-class SpannerAdmin
-  def self.get_project_id
-    return ENV["PROJECT_ID"] if ENV["PROJECT_ID"]
-
-    Google::Cloud::Spanner.default_credentials.project_id
-  end
-
-  def initialize(project_id:, instance_id:, database_id:)
-    @project_id = project_id
-    @instance_id = instance_id
-    @database_id = database_id
-  end
-
-  def create_instance
-    return if instance_exists?
-
-    instance_admin.create_instance(
-      parent: project_path,
-      instance_id: @instance_id,
-      instance: {
-        name: instance_path,
-        config: instance_config_path,
-        display_name: @instance_id,
-        node_count: 1
-      }
-    ).wait_until_done!
-  end
-
-  def create_database
-    database_admin.create_database(
-      parent: instance_path,
-      create_statement: "CREATE DATABASE `#{@database_id}`",
-      extra_statements: ddls
-    ).wait_until_done!
-  end
-
-  def drop_database
-    database_admin.drop_database(database: database_path)
-  end
-
-  private
-
-  def ddls
-    schema_path = File.join(__dir__, "schema.sql")
-    File.read(schema_path).split(";").map(&:strip).reject(&:empty?)
-  end
-
-  def instance_exists?
-    instance_admin.list_instances(parent: project_path)
-      .any? { |instance| instance.name == instance_path }
-  end
-
-  def project_path
-    @project_path ||= instance_admin.project_path(project: @project_id)
-  end
-
-  def instance_config_path
-    @instance_config_path ||= instance_admin.instance_config_path(
-      project: @project_id,
-      instance_config: "regional-us-central1"
-    )
-  end
-
-  def instance_path
-    @instance_path ||= instance_admin.instance_path(
-      project: @project_id,
-      instance: @instance_id
-    )
-  end
-
-  def database_path
-    @database_path ||= database_admin.database_path(
-      project: @project_id,
-      instance: @instance_id,
-      database: @database_id
-    )
-  end
-
-  def instance_admin
-    @instance_admin ||= Google::Cloud::Spanner::Admin::Instance.instance_admin(
-      project_id: @project_id
-    )
-  end
-
-  def database_admin
-    @database_admin ||= Google::Cloud::Spanner::Admin::Database.database_admin(
-      project_id: @project_id
-    )
-  end
-end
+require_relative "spanner_admin"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -137,7 +46,8 @@ RSpec.configure do |config|
   admin = SpannerAdmin.new(
     project_id: config.project_id,
     instance_id: config.instance_id,
-    database_id: config.database_id
+    database_id: config.database_id,
+    schema_file: File.expand_path("./schema.sql", __dir__)
   )
 
   # Create instance and database for testing


### PR DESCRIPTION
This gem is mainly for testing, so partitioned DML wouldn't be good for it.

Added `:batch_deletion` option to use [batch_update](https://www.rubydoc.info/gems/google-cloud-spanner/2.16.1/Google%2FCloud%2FSpanner%2FBatchUpdate:batch_update) ([batch DML](https://cloud.google.com/spanner/docs/dml-tasks#use-batch)) for performance.

However, batch_update isn't much faster than sequential deletion.
With `scripts/schema.sql`, trying deletion 100 times, `scripts/performance_test.rb` got following results:

```sh
❯ bundle exec ruby scripts/performance_test.rb
Creating instance...                                                                                           
Creating database...                                                                                           
                                                       
                           user     system      total        real
test_batch_update      4.463483   0.756185   5.219668 ( 65.044635)                                             
test_delete_each       6.025656   1.135578   7.161234 ( 73.651115)                                             
                                                                                                               
Dropping database... 
```

I decided to keep the sequential deletion default.

Close #4 