### PR TITLE
Fix configuration when the database_cleaner-active_record gem is loaded

### DIFF
--- a/lib/database_cleaner/spanner/deletion.rb
+++ b/lib/database_cleaner/spanner/deletion.rb
@@ -129,11 +129,11 @@ module DatabaseCleaner
         name = "primary" if name == :default
 
         # DB config from ActiveRecord
-        config = ActiveRecord::Base.configurations.configs_for(name: name.to_s).configuration_hash
+        config = ::ActiveRecord::Base.configurations.configs_for(name: name.to_s).configuration_hash
 
         # Keep metadata tables
-        @except << ActiveRecord::SchemaMigration.table_name # schema_migrations
-        @except << ActiveRecord::Base.internal_metadata_table_name # ar_internal_metadata
+        @except << ::ActiveRecord::SchemaMigration.table_name # schema_migrations
+        @except << ::ActiveRecord::Base.internal_metadata_table_name # ar_internal_metadata
 
         Google::Cloud::Spanner.new(
           project_id: config[:project],

--- a/spec/database_cleaner/spanner/configuration_spec.rb
+++ b/spec/database_cleaner/spanner/configuration_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# classes to simulate database_cleaner/active_record and active_record
+module DatabaseCleaner
+  module ActiveRecord
+    class Base; end
+  end
+end
+
+module ActiveRecord
+  class Base
+    def self.internal_metadata_table_name
+      "ar_internal_metadata"
+    end
+  end
+
+  class SchemaMigration
+    def self.table_name
+      "schema_migrations"
+    end
+  end
+end
+
+require "google/cloud/spanner"
+require "google/cloud/spanner/admin/database"
+
+require "database_cleaner/spanner/deletion"
+
+RSpec.describe DatabaseCleaner::Spanner::Deletion do
+  before do
+    configuration = <<~YAML
+      adapter: spanner
+      instance: #{RSpec.configuration.instance_id}
+      project: #{RSpec.configuration.project_id}
+      database: #{RSpec.configuration.database_id}
+    YAML
+    configuration_hash = YAML.safe_load(configuration).tap { |hash|
+      hash.keys.each { |key| hash[key.to_sym] = hash.delete(key) }
+    }
+
+    configs_for = double("ActiveRecord::DatabaseConfigurations::HashConfig", configuration_hash: configuration_hash)
+    configurations = double("ActiveRecord::DatabaseConfigurations", configs_for: configs_for)
+    allow(ActiveRecord::Base).to receive(:configurations).and_return(configurations)
+  end
+
+  it "can generate cloud spanner client from database name when database_cleaner-active_record is in use" do
+    instance = described_class.new
+    expect { instance.send(:configure_client_from_active_record, :spanner) }.to_not raise_error
+  end
+end


### PR DESCRIPTION
### problem

I'm working on a project that needs to use multiple databases, including Spanner, so we're also including the `database_cleaner-active_record` gem.

That project defines a class named `DatabaseCleaner::ActiveRecord::Base` which ends up being referenced by the bare `ActiveRecord::Base` calls in lib/database_cleaner/spanner/deletion.rb.

This results in an error: 

```
#<NoMethodError: undefined method `configurations' for DatabaseCleaner::ActiveRecord::Base:Class> with backtrace:
  # ./lib/database_cleaner/spanner/deletion.rb:132:in `configure_client_from_active_record'
```

### solution

This PR adds the `::` prefix to the calls to `ActiveRecord` modules/classes to ensure proper scope resolution. 

### testing notes

This PR includes a spec that simulates the same namespace / scope resolution conditions that caused the bug without adding the peer-dependency gems, `activerecord` and `database_cleaner-active_record`, to the project. 

The test fails with the original version of `lib/database_cleaner/spanner/deletion.rb` and passes with the patched version when I'm using the spanner emulator locally. 

I have not tested the changes against a cloud-hosted Spanner instance, but that shouldn't make a difference. 
