### PR TITLE
Fast call failure, fix Rails compatibility

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,6 +1,6 @@
 # For available configuration options, see:
 #   https://github.com/testdouble/standard
-ruby_version: 2.6
+ruby_version: 3.2
 
 ignore:
   - example/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,5 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 13.0"
-
 gem "rspec", "~> 3.0"
-
 gem "standard", "~> 1.3"

--- a/database_cleaner-spanner.gemspec
+++ b/database_cleaner-spanner.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "google-cloud-spanner", "~> 2.10"
+  spec.add_dependency "google-cloud-spanner", "~> 2.22"
   spec.add_dependency "database_cleaner-core", "~> 2.0.0"
 
   spec.add_development_dependency "simplecov"

--- a/lib/database_cleaner/spanner/deletion.rb
+++ b/lib/database_cleaner/spanner/deletion.rb
@@ -151,7 +151,7 @@ module DatabaseCleaner
         config = ::ActiveRecord::Base.configurations.configs_for(name: name.to_s).configuration_hash
 
         # Keep metadata tables
-        @except << ::ActiveRecord::SchemaMigration.table_name # schema_migrations
+        @except << ::ActiveRecord::Base.connection.schema_migration.table_name # schema_migrations
         @except << ::ActiveRecord::Base.internal_metadata_table_name # ar_internal_metadata
 
         Google::Cloud::Spanner.new(

--- a/lib/database_cleaner/spanner/deletion.rb
+++ b/lib/database_cleaner/spanner/deletion.rb
@@ -129,11 +129,11 @@ module DatabaseCleaner
         name = "primary" if name == :default
 
         # DB config from ActiveRecord
-        config = ActiveRecord::Base.configurations.configs_for(name: name.to_s).configuration_hash
+        config = ::ActiveRecord::Base.configurations.configs_for(name: name.to_s).configuration_hash
 
         # Keep metadata tables
-        @except << ActiveRecord::SchemaMigration.table_name # schema_migrations
-        @except << ActiveRecord::Base.internal_metadata_table_name # ar_internal_metadata
+        @except << ::ActiveRecord::SchemaMigration.table_name # schema_migrations
+        @except << ::ActiveRecord::Base.internal_metadata_table_name # ar_internal_metadata
 
         Google::Cloud::Spanner.new(
           project_id: config[:project],

--- a/lib/database_cleaner/spanner/table_dependency.rb
+++ b/lib/database_cleaner/spanner/table_dependency.rb
@@ -1,4 +1,3 @@
-require "set"
 require "tsort"
 
 module DatabaseCleaner

--- a/spec/database_cleaner/spanner/configuration_spec.rb
+++ b/spec/database_cleaner/spanner/configuration_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# classes to simulate database_cleaner/active_record and active_record
+module DatabaseCleaner
+  module ActiveRecord
+    class Base; end
+  end
+end
+
+module ActiveRecord
+  class Base
+    def self.internal_metadata_table_name
+      "ar_internal_metadata"
+    end
+  end
+
+  class SchemaMigration
+    def self.table_name
+      "schema_migrations"
+    end
+  end
+end
+
+require "google/cloud/spanner"
+require "google/cloud/spanner/admin/database"
+
+require "database_cleaner/spanner/deletion"
+
+RSpec.describe DatabaseCleaner::Spanner::Deletion do
+  before do
+    configuration = <<~YAML
+      adapter: spanner
+      instance: #{RSpec.configuration.instance_id}
+      project: #{RSpec.configuration.project_id}
+      database: #{RSpec.configuration.database_id}
+    YAML
+    configuration_hash = YAML.safe_load(configuration).tap { |hash|
+      hash.keys.each { |key| hash[key.to_sym] = hash.delete(key) }
+    }
+
+    configs_for = double("ActiveRecord::DatabaseConfigurations::HashConfig", configuration_hash: configuration_hash)
+    configurations = double("ActiveRecord::DatabaseConfigurations", configs_for: configs_for)
+    allow(ActiveRecord::Base).to receive(:configurations).and_return(configurations)
+  end
+
+  it "can generate cloud spanner client from database name when database_cleaner-active_record is in use" do
+    instance = described_class.new
+    expect { instance.send(:configure_client_from_active_record, :spanner) }.to_not raise_error
+  end
+end

--- a/spec/local.env
+++ b/spec/local.env
@@ -1,0 +1,1 @@
+SPANNER_EMULATOR_HOST="localhost:9010"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,15 @@ require "database_cleaner/spanner"
 
 require "google/cloud/spanner"
 
+dotenv = File.expand_path("local.env", __dir__)
+if File.exist?(dotenv)
+  File.read(dotenv).each_line do |line|
+    line.split("=").tap do |key, value|
+      ENV[key] = value.gsub(/^['"]|['"]$/, "")
+    end
+  end
+end
+
 require_relative "spanner_admin"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Two items. 

### open transaction timeouts 

When the Spanner local emulator has hung open transactions, the default connection timeout of 60s kills the whole test process silently for a minute. This sucks. [See documentation of the issue here](https://gist.github.com/abachman/1c895656b094cfa92785f7703043837a#file-readme-md). This PR adds query options to die quickly if the query fails to return anything in 3 seconds.

### rails 7.1 compatibility 

See [database_cleaner-active_record#78](https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/78) for similar change.

Rails 7.0 introduced `::ActiveRecord::Base.connection.schema_migration.table_name` as a way of getting the schema migrations metadata table name. Rails 7.1 took away `::ActiveRecord::SchemaMigration.table_name`.
